### PR TITLE
correct loss bug

### DIFF
--- a/utils/losses.py
+++ b/utils/losses.py
@@ -6,9 +6,9 @@ import torch
 from torch.nn import functional as F
 
 
-def getValid(true, pred, nonvalid=-1):
-    """ On CDNEt dataset, the frmaes are not fully labeled. Only some predefined region of them are labeled.
-    This function extracts the labeled part from ground truth and the corresponding part from prediction as  1-D tensors
+def getValid(true, pred):
+    """ On CDNEt dataset, the frames are not fully labeled. Only some predefined region of them are labeled.
+    This function extracts the labeled part from ground truth and the corresponding part from prediction as 1-D tensors
     Args:
         true (tensor): Ground truth tensor of shape Bx1xHxW
         preds (tensor): Prediction tensor of shape Bx1xHxW
@@ -18,25 +18,17 @@ def getValid(true, pred, nonvalid=-1):
         (tensor): 1-D tensor containing the valid pixels of ground truth
         (tensor): 1-D tensor of prediction corresponding the valid ground truth pixels
     """
-    """# Turn predictions and labels into 1D arrays
-    true_valid = true.reshape(-1)
-    pred_valid = pred.reshape(-1)
-
-    # Mask of the known parts of the ground truth
-    mask =  torch.where(true_valid==nonvalid, torch.tensor(0), torch.tensor(1)).type(torch.bool)
-
-    # Discard the unknown parts from the predictions and labels
-    return torch.masked_select(true_valid, mask), torch.masked_select(pred_valid, mask)"""
 
     # Turn predictions and labels into 1D arrays
     true_valid = true.reshape(-1)
     pred_valid = pred.reshape(-1)
 
     # Mask of the known parts of the ground truth
-    mask = torch.where(true_valid == nonvalid, torch.tensor(0).cuda(), torch.tensor(1).cuda()).type(torch.bool)
+    mask = torch.where(true_valid < 0, torch.tensor(0).cuda(), torch.tensor(1).cuda()).type(torch.bool)
 
     # Discard the unknown parts from the predictions and labels
     return torch.masked_select(true_valid, mask), torch.masked_select(pred_valid, mask)
+
 
 def jaccard_loss(true, pred, smooth=100):
     """Computes the Jaccard loss, a.k.a the IoU loss.
@@ -56,6 +48,7 @@ def jaccard_loss(true, pred, smooth=100):
     jac = (intersection + smooth) / (torch.sum(true) + torch.sum(pred) - intersection + smooth)
     return (1 - jac) * smooth
 
+
 def weighted_crossentropy(true, pred, weight_pos=15, weight_neg=1):
     """Weighted cross entropy between ground truth and predictions
     Args:
@@ -71,6 +64,7 @@ def weighted_crossentropy(true, pred, weight_pos=15, weight_neg=1):
     weighted_bce = weight_vector * bce
     return -torch.mean(weighted_bce)
 
+
 def acc(true, pred):
     """Accuracy between ground truth and predictions
     Args:
@@ -80,6 +74,7 @@ def acc(true, pred):
         acc: Accuracy.
     """
     return torch.mean((true == pred.round()).float())
+
 
 def f_score(true, pred):
     """False Negative Rate between ground truth and predictions


### PR DESCRIPTION
Hi !

When training some models, we discover than sometime, in the function "f_score", the values of "true" tensor was lower than 0. This lead to some weird behavior when plotting the metrics : 

![image](https://user-images.githubusercontent.com/13920346/120216266-15395200-c237-11eb-95ee-ac615417da25.png)

after investigation, we discover than the issue was in the function "getValid". The docstring says that the "true" tensor have values in {-1, 0, 1}. However, due to the data augmentations, in reality the "true" tensor can have **any** values between -1 and 1.

The proposed solution to correct this is to change the way the mask is computed. See the code for more details.

Also, as the getValid function is called before computing the loss, I'm afraid this can have some other side-effects that could hurt the training performances.

What do you think ?

